### PR TITLE
PM-DIR review included

### DIFF
--- a/draft-ietf-opsawg-ipfix-on-path-telemetry-01.txt
+++ b/draft-ietf-opsawg-ipfix-on-path-telemetry-01.txt
@@ -5,10 +5,10 @@
 Network Working Group                                            T. Graf
 Internet-Draft                                                  Swisscom
 Intended status: Standards Track                               B. Claise
-Expires: 1 August 2023                                            Huawei
+Expires: 10 August 2023                                           Huawei
                                                            A. Huang Feng
                                                                INSA-Lyon
-                                                         28 January 2023
+                                                         6 February 2023
 
 
                     Export of On-Path Delay in IPFIX
@@ -35,7 +35,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 1 August 2023.
+   This Internet-Draft will expire on 10 August 2023.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 1]
+Graf, et al.             Expires 10 August 2023                 [Page 1]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
 Table of Contents
@@ -90,32 +90,29 @@ Table of Contents
      6.1.  Performance Metrics . . . . . . . . . . . . . . . . . . .  15
      6.2.  IPFIX Entities  . . . . . . . . . . . . . . . . . . . . .  15
        6.2.1.  PathDelayMeanDeltaMicroseconds  . . . . . . . . . . .  16
-       6.2.2.  PathDelayMeanDeltaNanoseconds . . . . . . . . . . . .  17
-       6.2.3.  PathDelayMinDeltaMicroseconds . . . . . . . . . . . .  17
-       6.2.4.  PathDelayMinDeltaNanoseconds  . . . . . . . . . . . .  17
-       6.2.5.  PathDelayMaxDeltaMicroseconds . . . . . . . . . . . .  18
-       6.2.6.  PathDelayMaxDeltaNanoseconds  . . . . . . . . . . . .  18
-       6.2.7.  PathDelaySumDeltaMicroseconds . . . . . . . . . . . .  18
-       6.2.8.  PathDelaySumDeltaNanoseconds  . . . . . . . . . . . .  19
-   7.  Operational Considerations  . . . . . . . . . . . . . . . . .  19
-     7.1.  Time Accuracy . . . . . . . . . . . . . . . . . . . . . .  19
-     7.2.  Mean Delay  . . . . . . . . . . . . . . . . . . . . . . .  19
-     7.3.  Reduced-size encoding . . . . . . . . . . . . . . . . . .  20
-     7.4.  IOAM Application  . . . . . . . . . . . . . . . . . . . .  20
-   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  20
-   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  20
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  20
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  20
+       6.2.2.  PathDelayMinDeltaMicroseconds . . . . . . . . . . . .  16
+       6.2.3.  PathDelayMaxDeltaMicroseconds . . . . . . . . . . . .  17
+       6.2.4.  PathDelaySumDeltaMicroseconds . . . . . . . . . . . .  17
+   7.  Operational Considerations  . . . . . . . . . . . . . . . . .  17
+     7.1.  Time Accuracy . . . . . . . . . . . . . . . . . . . . . .  17
+     7.2.  Mean Delay  . . . . . . . . . . . . . . . . . . . . . . .  18
+     7.3.  Reduced-size encoding . . . . . . . . . . . . . . . . . .  18
+     7.4.  IOAM Application  . . . . . . . . . . . . . . . . . . . .  18
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  18
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  18
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  19
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  19
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  21
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 2]
+
+
+Graf, et al.             Expires 10 August 2023                 [Page 2]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
-
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  21
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
 
 1.  Introduction
 
@@ -145,7 +142,7 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
    exposes performance metrics allowing to determine how much delay has
    been accumulated on which hop.
 
-   This document defines eight new IPFIX Information Elements (IEs),
+   This document defines four new IPFIX Information Elements (IEs),
    exposing the On-Path delay on IOAM transit and decapsulation nodes,
    following the postcard mode principles.  Since these IPFIX IEs are
    performance metrics [RFC8911], they must be registered in the "IANA
@@ -165,28 +162,31 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 3]
+
+
+
+Graf, et al.             Expires 10 August 2023                 [Page 3]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
-+-----------------------------+-------------------------------------+
-|      Performance Metric     |        IPFIX Information Element    |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMeanDeltaMicroseconds (TBD5)|
-|P_RFCTBD_Seconds_Mean (TBD1) |PathDelayMeanDeltaNanoseconds (TBD6) |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMinDeltaMicroseconds (TBD7) |
-|P_RFCTBD_Seconds_Min (TBD2)  |PathDelayMinDeltaNanoseconds (TBD8)  |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMaxDeltaMicroseconds (TBD9) |
-|P_RFCTBD_Seconds_Max (TBD3)  |PathDelayMaxDeltaNanoseconds (TBD10) |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelaySumDeltaMicroseconds (TBD11)|
-|P_RFCTBD_Seconds_Sum (TBD4)  |PathDelaySumDeltaNanoseconds (TBD12) |
-+-----------------------------+-------------------------------------+
+  +------------------------------------+-------------------------------+
+  |      Performance Metric            |  IPFIX Information Element    |
+  +------------------------------------+-------------------------------+
+  |OWDelay_HybridType1_Passive_I       |PathDelayMeanDeltaMicroseconds |
+  |P_RFC[RFC-to-be]_Seconds_Mean (TBD1)|(TBD5)                         |
+  +------------------------------------+-------------------------------+
+  |OWDelay_HybridType1_Passive_I       |PathDelayMinDeltaMicroseconds  |
+  |P_RFC[RFC-to-be]_Seconds_Min (TBD2) |(TBD6)                         |
+  +------------------------------------+-------------------------------+
+  |OWDelay_HybridType1_Passive_I       |PathDelayMaxDeltaMicroseconds  |
+  |P_RFC[RFC-to-be]_Seconds_Max (TBD3) |(TBD7)                         |
+  +------------------------------------+-------------------------------+
+  |OWDelay_HybridType1_Passive_I       |PathDelaySumDeltaMicroseconds  |
+  |P_RFC[RFC-to-be]_Seconds_Sum (TBD4) |(TBD8)                         |
+  +------------------------------------+-------------------------------+
 
-Table 1: Correspondance between IPFIX IE and performance metric registry
+  Table 1: Correspondance between IPFIX IE and Performance Metric
 
    The delay is measured by calculating the difference between the
    timestamp imposed with On-Path Telemetry in the packet at the IOAM
@@ -221,9 +221,9 @@ Table 1: Correspondance between IPFIX IE and performance metric registry
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 4]
+Graf, et al.             Expires 10 August 2023                 [Page 4]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
    On the usecase showed in Figure 1 using On-path Telemetry to export
@@ -277,9 +277,9 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 5]
+Graf, et al.             Expires 10 August 2023                 [Page 5]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
 3.1.  IP One-Way Delay Hybrid Type I Passive Performance Metrics
@@ -310,36 +310,36 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 3.1.1.3.  Name
 
-   TBD1: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Mean
+   TBD1: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Mean
 
-   TBD2: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Min
+   TBD2: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Min
 
-   TBD3: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Max
+   TBD3: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max
 
-   TBD4: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Sum
+   TBD4: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum
 
 3.1.1.4.  URI
 
    URL: https://www.iana.org/assignments/performance-metrics/
-   OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Mean
+   OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Mean
 
    URL: https://www.iana.org/assignments/performance-metrics/
-   OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Min
+   OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Min
 
    URL: https://www.iana.org/assignments/performance-metrics/
-   OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Max
+   OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max
 
 
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 6]
+Graf, et al.             Expires 10 August 2023                 [Page 6]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
    URL: https://www.iana.org/assignments/performance-metrics/
-   OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Sum
+   OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum
 
 3.1.2.  Description
 
@@ -389,9 +389,9 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 7]
+Graf, et al.             Expires 10 August 2023                 [Page 7]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
    Section 3.4 of [RFC7679] provides the reference definition of the
@@ -445,9 +445,9 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 8]
+Graf, et al.             Expires 10 August 2023                 [Page 8]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
 3.3.4.  Sampling Distribution
@@ -501,9 +501,9 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                 [Page 9]
+Graf, et al.             Expires 10 August 2023                 [Page 9]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
       "host B" is synonymous with the IP address used at host B.
@@ -557,9 +557,9 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                [Page 10]
+Graf, et al.             Expires 10 August 2023                [Page 10]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
    Mean:  The time value of the result is expressed in units of seconds,
@@ -613,9 +613,9 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                [Page 11]
+Graf, et al.             Expires 10 August 2023                [Page 11]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
       as a positive value of type decimal64 with fraction digits = 9
@@ -669,9 +669,9 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-Graf, et al.              Expires 1 August 2023                [Page 12]
+Graf, et al.             Expires 10 August 2023                [Page 12]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
 3.4.3.1.  Status
@@ -704,41 +704,15 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
       node with the IOAM domain (either an IOAM transit node or an IOAM
       decapsulation node).
 
-   PathDelayMeanDeltaNanoseconds
-      32-bit unsigned integer that identifies the mean path delay in
-      nanoseconds, between the IOAM encapsulation node and the local
-      node with the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node).
-
    PathDelayMinDeltaMicroseconds
       16-bit unsigned integer that identifies the lowest path delay in
       microseconds, between the IOAM encapsulation node and the local
       node with the IOAM domain (either an IOAM transit node or an IOAM
       decapsulation node).
 
-   PathDelayMinDeltaNanoseconds
-      32-bit unsigned integer that identifies the lowest path delay in
-      nanoseconds, between the IOAM encapsulation node and the local
-      node with the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node).
-
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 13]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
-
    PathDelayMaxDeltaMicroseconds
       16-bit unsigned integer that identifies the highest path delay in
       microseconds, between the IOAM encapsulation node and the local
-      node with the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node).
-
-   PathDelayMaxDeltaNanoseconds
-      32-bit unsigned integer that identifies the highest path delay in
-      nanoseconds, between the IOAM encapsulation node and the local
       node with the IOAM domain (either an IOAM transit node or an IOAM
       decapsulation node).
 
@@ -748,11 +722,13 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
       node with the IOAM domain (either an IOAM transit node or an IOAM
       decapsulation node).
 
-   PathDelaySumDeltaNanoseconds
-      64-bit unsigned integer that identifies the sum of the path delay
-      in nanoseconds, between the IOAM encapsulation node and the local
-      node with the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node).
+
+
+
+Graf, et al.             Expires 10 August 2023                [Page 13]
+
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
+
 
 5.  Use Cases
 
@@ -777,15 +753,6 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
       MPLS top label IPv4 address or SRv6 active segment contributed to
       how much delay.
 
-
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 14]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
-
    *  BGP communities are often used for setting a path priority or
       service selection.  With bgpDestinationExtendedCommunityList(488)
       or bgpDestinationCommunityList(485) or
@@ -800,6 +767,24 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
    Taking figure 1 from section 1 as topology example.  Below example
    table shows the aggregated delay per each node, egressInterface and
    srhActiveSegmentIPv6.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Graf, et al.             Expires 10 August 2023                [Page 14]
+
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
+
 
         +------------+------+-----------------+----------------------+
         | Path Delay | Node | egressInterface | srhActiveSegmentIPv6 |
@@ -830,18 +815,6 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
    at "IANA Performance Metric Registry [IANA-PERF-METRIC] and assign
    the following initial code points.
 
-
-
-
-
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 15]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
-
      +-------+--------------------------------+
      |Element|              Name              |
      |   ID  |                                |
@@ -849,32 +822,27 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
      | TBD5  | PathDelayMeanDeltaMicroseconds |
      |       |                                |
      +-------+--------------------------------+
-     | TBD6  | PathDelayMeanDeltaNanoseconds  |
+     | TBD6  | PathDelayMinDeltaMicroseconds  |
      |       |                                |
      +-------+--------------------------------+
-     | TBD7  | PathDelayMinDeltaMicroseconds  |
+     | TBD7  | PathDelayMaxDeltaMicroseconds  |
      |       |                                |
      +-------+--------------------------------+
-     | TBD8  | PathDelayMinDeltaNanoseconds   |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD9  | PathDelayMaxDeltaMicroseconds  |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD10 | PathDelayMaxDeltaNanoseconds   |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD11 | PathDelaySumDeltaMicroseconds  |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD12 | PathDelaySumDeltaNanoseconds   |
+     | TBD8 | PathDelaySumDeltaMicroseconds  |
      |       |                                |
      +-------+--------------------------------+
   Table 3: Creates IPFIX IEs in the "IPFIX Information Elements" registry
 
    Note to the RFC-Editor:
 
-   *  Please replace TBD5 - TBD12 with the values allocated by IANA
+
+
+Graf, et al.             Expires 10 August 2023                [Page 15]
+
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
+
+
+   *  Please replace TBD5 - TBD8 with the values allocated by IANA
 
    *  Please replace the [RFC-to-be] with the RFC number assigned to
       this document
@@ -888,157 +856,87 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
    Description:  This Information Element identifies the mean path delay
       between the IOAM encapsulation node and the local node with the
       IOAM domain (either an IOAM transit node or an IOAM decapsulation
-      node) in microseconds.
-
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 16]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
+      node) in microseconds, according to
+      OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Mean in the
+      IANA Performance Metric Registry
 
    Abstract Data Type:  unsigned32
 
    Data Type Semantics:  deltaCounter
 
-   Reference:  [RFC-to-be], xxx
+   Reference:  [RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-
+      be]_Seconds_Mean in the IANA Performance Metric Registry.
 
-6.2.2.  PathDelayMeanDeltaNanoseconds
-
-   Name:  PathDelayMeanDeltaNanoseconds
-
-   ElementID:  TBD6
-
-   Description:  This Information Element identifies the mean path
-      delaybetween the IOAM encapsulation node and the local node with
-      the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node) in nanoseconds.
-
-   Abstract Data Type:  unsigned32
-
-   Data Type Semantics:  deltaCounter
-
-   Reference:  [RFC-to-be], xxx
-
-6.2.3.  PathDelayMinDeltaMicroseconds
+6.2.2.  PathDelayMinDeltaMicroseconds
 
    Name:  PathDelayMinDeltaMicroseconds
 
-   ElementID:  TBD7
+   ElementID:  TBD6
 
    Description:  This Information Element identifies the lowest path
       delay between the IOAM encapsulation node and the local node with
       the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node) in microseconds.
+      decapsulation node) in microseconds, according to the
+      OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Min in the
+      IANA Performance Metric Registry.
 
    Abstract Data Type:  unsigned32
 
    Data Type Semantics:  deltaCounter
 
-   Reference:  [RFC-to-be], xxx
-
-6.2.4.  PathDelayMinDeltaNanoseconds
-
-   Name:  PathDelayMinDeltaNanoseconds
-
-   ElementID:  TBD8
-
-   Description:  This Information Element identifies the lowest path
+   Reference:  [RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-
+      be]_Seconds_Min in the IANA Performance Metric Registry.
 
 
 
 
-Graf, et al.              Expires 1 August 2023                [Page 17]
+
+
+
+Graf, et al.             Expires 10 August 2023                [Page 16]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
 
-      delay between the IOAM encapsulation node and the local node with
-      the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node) in nanoseconds.
-
-   Abstract Data Type:  unsigned32
-
-   Data Type Semantics:  deltaCounter
-
-   Reference:  [RFC-to-be], xxx
-
-6.2.5.  PathDelayMaxDeltaMicroseconds
+6.2.3.  PathDelayMaxDeltaMicroseconds
 
    Name:  PathDelayMaxDeltaMicroseconds
 
-   ElementID:  TBD9
+   ElementID:  TBD7
 
    Description:  This Information Element identifies the highest path
       delay between the IOAM encapsulation node and the local node with
       the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node) in microseconds.
+      decapsulation node) in microseconds, according to
+      OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max in the
+      IANA Performance Metric Registry.
 
    Abstract Data Type:  unsigned32
 
    Data Type Semantics:  deltaCounter
 
-   Reference:  [RFC-to-be], xxx
+   Reference:  [RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-
+      be]_Seconds_Max in the IANA Performance Metric Registry.
 
-6.2.6.  PathDelayMaxDeltaNanoseconds
-
-   Name:  PathDelayMaxDeltaNanoseconds
-
-   ElementID:  TBD10
-
-   Description:  This Information Element identifies the highest path
-      delay between the IOAM encapsulation node and the local node with
-      the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node) in nanoseconds.
-
-   Abstract Data Type:  unsigned32
-
-   Data Type Semantics:  deltaCounter
-
-   Reference:  [RFC-to-be], xxx
-
-6.2.7.  PathDelaySumDeltaMicroseconds
+6.2.4.  PathDelaySumDeltaMicroseconds
 
    Name:  PathDelaySumDeltaMicroseconds
 
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 18]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
-
-   ElementID:  TBD11
+   ElementID:  TBD8
 
    Description:  This Information Element identifies the sum of the path
       delay between the IOAM encapsulation node and the local node with
       the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node) in microseconds.
+      decapsulation node) in microseconds, according to
+      OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum in the
+      IANA Performance Metric Registry.
 
    Abstract Data Type:  unsigned64
 
    Data Type Semantics:  deltaCounter
 
-   Reference:  [RFC-to-be], xxx
-
-6.2.8.  PathDelaySumDeltaNanoseconds
-
-   Name:  PathDelaySumDeltaNanoseconds
-
-   ElementID:  TBD12
-
-   Description:  This Information Element identifies the sum of the path
-      delay between the IOAM encapsulation node and the local node with
-      the IOAM domain (either an IOAM transit node or an IOAM
-      decapsulation node) in nanoseconds.
-
-   Abstract Data Type:  unsigned64
-
-   Data Type Semantics:  deltaCounter
-
-   Reference:  [RFC-to-be], xxx
+   Reference:  [RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-
+      be]_Seconds_Sum in the IANA Performance Metric Registry.
 
 7.  Operational Considerations
 
@@ -1047,24 +945,21 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
    The same recommendation as defined in section 4.5 of [RFC5153] for
    IPFIX applies in terms of clock precision to this document as well.
 
+
+
+
+
+Graf, et al.             Expires 10 August 2023                [Page 17]
+
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
+
+
 7.2.  Mean Delay
 
    The mean (average) path delay can be calculated by dividing the
-   PathDelaySumDeltaMicroseconds(TBD5) or
-   PathDelaySumDeltaNanoseconds(TBD6) by the packetDeltaCount(2) at the
+   PathDelaySumDeltaMicroseconds(TBD5) by the packetDeltaCount(2) at the
    IPFIX data collection in order to offload the IPFIX Exporter from
    calculating the mean for every Flow at export time.
-
-
-
-
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 19]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
 
 7.3.  Reduced-size encoding
 
@@ -1108,19 +1003,14 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 10.  References
 
-10.1.  Normative References
-
-   [IANA-PERF-METRIC]
-              "IANA Performance Metric Registry",
-              <https://www.iana.org/assignments/performance-metrics/
-              performance-metrics.xhtml>.
 
 
-
-Graf, et al.              Expires 1 August 2023                [Page 20]
+Graf, et al.             Expires 10 August 2023                [Page 18]
 
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
 
+
+10.1.  Normative References
 
    [RFC7012]  Claise, B., Ed. and B. Trammell, Ed., "Information Model
               for IP Flow Information Export (IPFIX)", RFC 7012,
@@ -1167,21 +1057,27 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
               <https://www.ietf.org/archive/id/draft-song-opsawg-ifit-
               framework-19.txt>.
 
+
+
+
+
+Graf, et al.             Expires 10 August 2023                [Page 19]
+
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
+
+
    [I-D.tgraf-opsawg-ipfix-srv6-srh]
               Graf, T., Claise, B., and P. Francois, "Export of Segment
               Routing IPv6 Information in IP Flow Information Export
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 21]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
-
               (IPFIX)", Work in Progress, Internet-Draft, draft-tgraf-
               opsawg-ipfix-srv6-srh-05, 24 July 2022,
               <https://www.ietf.org/archive/id/draft-tgraf-opsawg-ipfix-
               srv6-srh-05.txt>.
+
+   [IANA-PERF-METRIC]
+              "IANA Performance Metric Registry",
+              <https://www.iana.org/assignments/performance-metrics/
+              performance-metrics.xhtml>.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -1217,6 +1113,15 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
               Metrics", RFC 6049, DOI 10.17487/RFC6049, January 2011,
               <https://www.rfc-editor.org/info/rfc6049>.
 
+
+
+
+
+Graf, et al.             Expires 10 August 2023                [Page 20]
+
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
+
+
    [RFC6703]  Morton, A., Ramachandran, G., and G. Maguluri, "Reporting
               IP Network Performance Metrics: Different Points of View",
               RFC 6703, DOI 10.17487/RFC6703, August 2012,
@@ -1225,14 +1130,6 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
    [RFC6991]  Schoenwaelder, J., Ed., "Common YANG Data Types",
               RFC 6991, DOI 10.17487/RFC6991, July 2013,
               <https://www.rfc-editor.org/info/rfc6991>.
-
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 22]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
-
 
    [RFC7011]  Claise, B., Ed., Trammell, B., Ed., and P. Aitken,
               "Specification of the IP Flow Information Export (IPFIX)
@@ -1271,6 +1168,16 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 Authors' Addresses
 
+
+
+
+
+
+Graf, et al.             Expires 10 August 2023                [Page 21]
+
+Internet-Draft      Export of On-Path Delay in IPFIX       February 2023
+
+
    Thomas Graf
    Swisscom
    Binzring 17
@@ -1282,12 +1189,6 @@ Authors' Addresses
    Benoit Claise
    Huawei
    Email: benoit.claise@huawei.com
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 23]
-
-Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
    Alex Huang Feng
@@ -1328,17 +1229,4 @@ Internet-Draft      Export of On-Path Delay in IPFIX        January 2023
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Graf, et al.              Expires 1 August 2023                [Page 24]
+Graf, et al.             Expires 10 August 2023                [Page 22]

--- a/draft-ietf-opsawg-ipfix-on-path-telemetry-01.xml
+++ b/draft-ietf-opsawg-ipfix-on-path-telemetry-01.xml
@@ -68,7 +68,7 @@
       </address>
     </author>
 
-    <date day="28" month="January" year="2023"/>
+    <date day="6" month="February" year="2023"/>
 
     <abstract>
       <t>This document introduces new IP Flow Information Export (IPFIX)
@@ -107,7 +107,7 @@
       exposes performance metrics allowing to determine how much delay has
       been accumulated on which hop.</t>
 
-      <t>This document defines eight new IPFIX Information Elements (IEs),
+      <t>This document defines four new IPFIX Information Elements (IEs),
       exposing the On-Path delay on IOAM transit and decapsulation nodes,
       following the postcard mode principles. Since these IPFIX IEs are
       performance metrics <xref target="RFC8911"/>, they must be registered in
@@ -132,19 +132,19 @@
 |      Performance Metric     |        IPFIX Information Element    |
 +-----------------------------+-------------------------------------+
 |OWDelay_HybridType1_Passive_I|PathDelayMeanDeltaMicroseconds (TBD5)|
-|P_RFCTBD_Seconds_Mean (TBD1) |PathDelayMeanDeltaNanoseconds (TBD6) |
+|P_RFCTBD_Seconds_Mean (TBD1) |                                     |
 +-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMinDeltaMicroseconds (TBD7) |
-|P_RFCTBD_Seconds_Min (TBD2)  |PathDelayMinDeltaNanoseconds (TBD8)  |
+|OWDelay_HybridType1_Passive_I|PathDelayMinDeltaMicroseconds (TBD6) |
+|P_RFCTBD_Seconds_Min (TBD2)  |                                     |
 +-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMaxDeltaMicroseconds (TBD9) |
-|P_RFCTBD_Seconds_Max (TBD3)  |PathDelayMaxDeltaNanoseconds (TBD10) |
+|OWDelay_HybridType1_Passive_I|PathDelayMaxDeltaMicroseconds (TBD7) |
+|P_RFCTBD_Seconds_Max (TBD3)  |                                     |
 +-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelaySumDeltaMicroseconds (TBD11)|
-|P_RFCTBD_Seconds_Sum (TBD4)  |PathDelaySumDeltaNanoseconds (TBD12) |
+|OWDelay_HybridType1_Passive_I|PathDelaySumDeltaMicroseconds (TBD8)|
+|P_RFCTBD_Seconds_Sum (TBD4)  |                                     |
 +-----------------------------+-------------------------------------+
           
-Table 1: Correspondance between IPFIX IE and performance metric registry
+Table 1: Correspondance between IPFIX IE and Performance Metric
        ]]></artwork>
         </figure></t>
 
@@ -652,21 +652,9 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           the local node with the IOAM domain (either an IOAM transit node or
           an IOAM decapsulation node).</t>
 
-          <t hangText="PathDelayMeanDeltaNanoseconds"><vspace blankLines="0"/>
-          32-bit unsigned integer that identifies the mean path delay in
-          nanoseconds, between the IOAM encapsulation node and the local node
-          with the IOAM domain (either an IOAM transit node or an IOAM
-          decapsulation node).</t>
-
           <t hangText="PathDelayMinDeltaMicroseconds"><vspace blankLines="0"/>
           16-bit unsigned integer that identifies the lowest path delay in
           microseconds, between the IOAM encapsulation node and the local node
-          with the IOAM domain (either an IOAM transit node or an IOAM
-          decapsulation node).</t>
-
-          <t hangText="PathDelayMinDeltaNanoseconds"><vspace blankLines="0"/>
-          32-bit unsigned integer that identifies the lowest path delay in
-          nanoseconds, between the IOAM encapsulation node and the local node
           with the IOAM domain (either an IOAM transit node or an IOAM
           decapsulation node).</t>
 
@@ -676,21 +664,9 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           with the IOAM domain (either an IOAM transit node or an IOAM
           decapsulation node).</t>
 
-          <t hangText="PathDelayMaxDeltaNanoseconds"><vspace blankLines="0"/>
-          32-bit unsigned integer that identifies the highest path delay in
-          nanoseconds, between the IOAM encapsulation node and the local node
-          with the IOAM domain (either an IOAM transit node or an IOAM
-          decapsulation node).</t>
-
           <t hangText="PathDelaySumDeltaMicroseconds"><vspace blankLines="0"/>
           32-bit unsigned integer that identifies the sum of the path delay in
           microseconds, between the IOAM encapsulation node and the local node
-          with the IOAM domain (either an IOAM transit node or an IOAM
-          decapsulation node).</t>
-
-          <t hangText="PathDelaySumDeltaNanoseconds"><vspace blankLines="0"/>
-          64-bit unsigned integer that identifies the sum of the path delay in
-          nanoseconds, between the IOAM encapsulation node and the local node
           with the IOAM domain (either an IOAM transit node or an IOAM
           decapsulation node).</t>
         </list></t>
@@ -777,25 +753,13 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
      | TBD5  | PathDelayMeanDeltaMicroseconds |
      |       |                                |
      +-------+--------------------------------+
-     | TBD6  | PathDelayMeanDeltaNanoseconds  |
+     | TBD6  | PathDelayMinDeltaMicroseconds  |
      |       |                                |
      +-------+--------------------------------+
-     | TBD7  | PathDelayMinDeltaMicroseconds  |
+     | TBD7  | PathDelayMaxDeltaMicroseconds  |
      |       |                                |
      +-------+--------------------------------+
-     | TBD8  | PathDelayMinDeltaNanoseconds   |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD9  | PathDelayMaxDeltaMicroseconds  |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD10 | PathDelayMaxDeltaNanoseconds   |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD11 | PathDelaySumDeltaMicroseconds  |
-     |       |                                |
-     +-------+--------------------------------+
-     | TBD12 | PathDelaySumDeltaNanoseconds   |
+     | TBD8 | PathDelaySumDeltaMicroseconds  |
      |       |                                |
      +-------+--------------------------------+
   Table 3: Creates IPFIX IEs in the "IPFIX Information Elements" registry
@@ -854,48 +818,6 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           </dl>
         </section>
 
-        <section anchor="IANAPathDelayMeanDeltaNanoseconds"
-                 title="PathDelayMeanDeltaNanoseconds">
-          <dl>
-            <dt>Name:</dt>
-
-            <dd>PathDelayMeanDeltaNanoseconds</dd>
-          </dl>
-
-          <dl>
-            <dt>ElementID:</dt>
-
-            <dd>TBD6</dd>
-          </dl>
-
-          <dl>
-            <dt>Description:</dt>
-
-            <dd>This Information Element identifies the mean path delaybetween
-            the IOAM encapsulation node and the local node with the IOAM
-            domain (either an IOAM transit node or an IOAM decapsulation node)
-            in nanoseconds.</dd>
-          </dl>
-
-          <dl>
-            <dt>Abstract Data Type:</dt>
-
-            <dd>unsigned32</dd>
-          </dl>
-
-          <dl>
-            <dt>Data Type Semantics:</dt>
-
-            <dd>deltaCounter</dd>
-          </dl>
-
-          <dl>
-            <dt>Reference:</dt>
-
-            <dd>[RFC-to-be], xxx</dd>
-          </dl>
-        </section>
-
         <section anchor="IANAPathDelayMinDeltaMicroseconds"
                  title="PathDelayMinDeltaMicroseconds">
           <dl>
@@ -907,7 +829,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <dl>
             <dt>ElementID:</dt>
 
-            <dd>TBD7</dd>
+            <dd>TBD6</dd>
           </dl>
 
           <dl>
@@ -917,48 +839,6 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
             between the IOAM encapsulation node and the local node with the
             IOAM domain (either an IOAM transit node or an IOAM decapsulation
             node) in microseconds.</dd>
-          </dl>
-
-          <dl>
-            <dt>Abstract Data Type:</dt>
-
-            <dd>unsigned32</dd>
-          </dl>
-
-          <dl>
-            <dt>Data Type Semantics:</dt>
-
-            <dd>deltaCounter</dd>
-          </dl>
-
-          <dl>
-            <dt>Reference:</dt>
-
-            <dd>[RFC-to-be], xxx</dd>
-          </dl>
-        </section>
-
-        <section anchor="IANAPathDelayMinDeltaNanoseconds"
-                 title="PathDelayMinDeltaNanoseconds">
-          <dl>
-            <dt>Name:</dt>
-
-            <dd>PathDelayMinDeltaNanoseconds</dd>
-          </dl>
-
-          <dl>
-            <dt>ElementID:</dt>
-
-            <dd>TBD8</dd>
-          </dl>
-
-          <dl>
-            <dt>Description:</dt>
-
-            <dd>This Information Element identifies the lowest path delay
-            between the IOAM encapsulation node and the local node with the
-            IOAM domain (either an IOAM transit node or an IOAM decapsulation
-            node) in nanoseconds.</dd>
           </dl>
 
           <dl>
@@ -991,7 +871,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <dl>
             <dt>ElementID:</dt>
 
-            <dd>TBD9</dd>
+            <dd>TBD7</dd>
           </dl>
 
           <dl>
@@ -1001,48 +881,6 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
             between the IOAM encapsulation node and the local node with the
             IOAM domain (either an IOAM transit node or an IOAM decapsulation
             node) in microseconds.</dd>
-          </dl>
-
-          <dl>
-            <dt>Abstract Data Type:</dt>
-
-            <dd>unsigned32</dd>
-          </dl>
-
-          <dl>
-            <dt>Data Type Semantics:</dt>
-
-            <dd>deltaCounter</dd>
-          </dl>
-
-          <dl>
-            <dt>Reference:</dt>
-
-            <dd>[RFC-to-be], xxx</dd>
-          </dl>
-        </section>
-
-        <section anchor="IANAPathDelayMaxDeltaNanoseconds"
-                 title="PathDelayMaxDeltaNanoseconds">
-          <dl>
-            <dt>Name:</dt>
-
-            <dd>PathDelayMaxDeltaNanoseconds</dd>
-          </dl>
-
-          <dl>
-            <dt>ElementID:</dt>
-
-            <dd>TBD10</dd>
-          </dl>
-
-          <dl>
-            <dt>Description:</dt>
-
-            <dd>This Information Element identifies the highest path delay
-            between the IOAM encapsulation node and the local node with the
-            IOAM domain (either an IOAM transit node or an IOAM decapsulation
-            node) in nanoseconds.</dd>
           </dl>
 
           <dl>
@@ -1075,7 +913,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <dl>
             <dt>ElementID:</dt>
 
-            <dd>TBD11</dd>
+            <dd>TBD8</dd>
           </dl>
 
           <dl>
@@ -1106,47 +944,6 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           </dl>
         </section>
 
-        <section anchor="IANAPathDelaySumDeltaNanoseconds"
-                 title="PathDelaySumDeltaNanoseconds">
-          <dl>
-            <dt>Name:</dt>
-
-            <dd>PathDelaySumDeltaNanoseconds</dd>
-          </dl>
-
-          <dl>
-            <dt>ElementID:</dt>
-
-            <dd>TBD12</dd>
-          </dl>
-
-          <dl>
-            <dt>Description:</dt>
-
-            <dd>This Information Element identifies the sum of the path delay
-            between the IOAM encapsulation node and the local node with the
-            IOAM domain (either an IOAM transit node or an IOAM decapsulation
-            node) in nanoseconds.</dd>
-          </dl>
-
-          <dl>
-            <dt>Abstract Data Type:</dt>
-
-            <dd>unsigned64</dd>
-          </dl>
-
-          <dl>
-            <dt>Data Type Semantics:</dt>
-
-            <dd>deltaCounter</dd>
-          </dl>
-
-          <dl>
-            <dt>Reference:</dt>
-
-            <dd>[RFC-to-be], xxx</dd>
-          </dl>
-        </section>
       </section>
     </section>
 
@@ -1159,8 +956,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
 
       <section anchor="OpsMeanDelay" title="Mean Delay">
         <t>The mean (average) path delay can be calculated by dividing the
-        PathDelaySumDeltaMicroseconds(TBD5) or
-        PathDelaySumDeltaNanoseconds(TBD6) by the packetDeltaCount(2) at the
+        PathDelaySumDeltaMicroseconds(TBD5) by the packetDeltaCount(2) at the
         IPFIX data collection in order to offload the IPFIX Exporter from
         calculating the mean for every Flow at export time.</t>
       </section>
@@ -1216,6 +1012,10 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
 
       <?rfc include='reference.RFC.8911'?>
 
+    </references>
+
+    <references title="Informative References">
+
       <reference anchor="IANA-PERF-METRIC"
                  target="https://www.iana.org/assignments/performance-metrics/performance-metrics.xhtml">
         <front>
@@ -1226,9 +1026,6 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <date/>
         </front>
       </reference>
-    </references>
-
-    <references title="Informative References">
        
 
       <?rfc include='reference.RFC.2119'?>

--- a/draft-ietf-opsawg-ipfix-on-path-telemetry-01.xml
+++ b/draft-ietf-opsawg-ipfix-on-path-telemetry-01.xml
@@ -128,21 +128,21 @@
 
       <t><figure>
           <artwork><![CDATA[
-+-----------------------------+-------------------------------------+
-|      Performance Metric     |        IPFIX Information Element    |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMeanDeltaMicroseconds (TBD5)|
-|P_RFCTBD_Seconds_Mean (TBD1) |                                     |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMinDeltaMicroseconds (TBD6) |
-|P_RFCTBD_Seconds_Min (TBD2)  |                                     |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelayMaxDeltaMicroseconds (TBD7) |
-|P_RFCTBD_Seconds_Max (TBD3)  |                                     |
-+-----------------------------+-------------------------------------+
-|OWDelay_HybridType1_Passive_I|PathDelaySumDeltaMicroseconds (TBD8)|
-|P_RFCTBD_Seconds_Sum (TBD4)  |                                     |
-+-----------------------------+-------------------------------------+
++------------------------------------+-------------------------------+
+|      Performance Metric            |  IPFIX Information Element    |
++------------------------------------+-------------------------------+
+|OWDelay_HybridType1_Passive_I       |PathDelayMeanDeltaMicroseconds |
+|P_RFC[RFC-to-be]_Seconds_Mean (TBD1)|(TBD5)                         |
++------------------------------------+-------------------------------+
+|OWDelay_HybridType1_Passive_I       |PathDelayMinDeltaMicroseconds  |
+|P_RFC[RFC-to-be]_Seconds_Min (TBD2) |(TBD6)                         |
++------------------------------------+-------------------------------+
+|OWDelay_HybridType1_Passive_I       |PathDelayMaxDeltaMicroseconds  |
+|P_RFC[RFC-to-be]_Seconds_Max (TBD3) |(TBD7)                         |
++------------------------------------+-------------------------------+
+|OWDelay_HybridType1_Passive_I       |PathDelaySumDeltaMicroseconds  |
+|P_RFC[RFC-to-be]_Seconds_Sum (TBD4) |(TBD8)                         |
++------------------------------------+-------------------------------+
           
 Table 1: Correspondance between IPFIX IE and Performance Metric
        ]]></artwork>
@@ -265,27 +265,27 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           </section>
 
           <section title="Name">
-            <t>TBD1: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Mean</t>
+            <t>TBD1: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Mean</t>
 
-            <t>TBD2: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Min</t>
+            <t>TBD2: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Min</t>
 
-            <t>TBD3: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Max</t>
+            <t>TBD3: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max</t>
 
-            <t>TBD4: OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Sum</t>
+            <t>TBD4: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum</t>
           </section>
 
           <section title="URI">
             <t>URL: <eref
-            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Mean"/></t>
+            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Mean"/></t>
 
             <t>URL: <eref
-            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Min"/></t>
+            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Min"/></t>
 
             <t>URL: <eref
-            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Max"/></t>
+            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max"/></t>
 
             <t>URL: <eref
-            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFCTBD_Seconds_Sum"/></t>
+            target="https://www.iana.org/assignments/performance-metrics/OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum"/></t>
           </section>
         </section>
 
@@ -769,7 +769,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
         <t>Note to the RFC-Editor:</t>
 
         <t><list style="symbols">
-            <t>Please replace TBD5 - TBD12 with the values allocated by
+            <t>Please replace TBD5 - TBD8 with the values allocated by
             IANA</t>
 
             <t>Please replace the [RFC-to-be] with the RFC number assigned to
@@ -796,7 +796,9 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
             <dd>This Information Element identifies the mean path delay
             between the IOAM encapsulation node and the local node with the
             IOAM domain (either an IOAM transit node or an IOAM decapsulation
-            node) in microseconds.</dd>
+            node) in microseconds, according to 
+            OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Mean in the 
+            IANA Performance Metric Registry</dd>
           </dl>
 
           <dl>
@@ -814,7 +816,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <dl>
             <dt>Reference:</dt>
 
-            <dd>[RFC-to-be], xxx</dd>
+            <dd>[RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Mean in the IANA Performance Metric Registry.</dd>
           </dl>
         </section>
 
@@ -838,7 +840,9 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
             <dd>This Information Element identifies the lowest path delay
             between the IOAM encapsulation node and the local node with the
             IOAM domain (either an IOAM transit node or an IOAM decapsulation
-            node) in microseconds.</dd>
+            node) in microseconds, according to the 
+            OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Min 
+            in the IANA Performance Metric Registry.</dd>
           </dl>
 
           <dl>
@@ -856,7 +860,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <dl>
             <dt>Reference:</dt>
 
-            <dd>[RFC-to-be], xxx</dd>
+            <dd>[RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Min in the IANA Performance Metric Registry.</dd>
           </dl>
         </section>
 
@@ -880,7 +884,9 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
             <dd>This Information Element identifies the highest path delay
             between the IOAM encapsulation node and the local node with the
             IOAM domain (either an IOAM transit node or an IOAM decapsulation
-            node) in microseconds.</dd>
+            node) in microseconds, according to 
+            OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max in the 
+            IANA Performance Metric Registry.</dd>
           </dl>
 
           <dl>
@@ -898,7 +904,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <dl>
             <dt>Reference:</dt>
 
-            <dd>[RFC-to-be], xxx</dd>
+            <dd>[RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max in the IANA Performance Metric Registry.</dd>
           </dl>
         </section>
 
@@ -922,7 +928,9 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
             <dd>This Information Element identifies the sum of the path delay
             between the IOAM encapsulation node and the local node with the
             IOAM domain (either an IOAM transit node or an IOAM decapsulation
-            node) in microseconds.</dd>
+            node) in microseconds, according to 
+            OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum in the 
+            IANA Performance Metric Registry.</dd>
           </dl>
 
           <dl>
@@ -940,7 +948,7 @@ Host 1  Encapsulation   Transit      Transit   Decapsulation  Host 2
           <dl>
             <dt>Reference:</dt>
 
-            <dd>[RFC-to-be], xxx</dd>
+            <dd>[RFC-to-be], OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum in the IANA Performance Metric Registry.</dd>
           </dl>
         </section>
 


### PR DESCRIPTION
- removed the nanoseconds related IPFIX IEs
- changed a couple of TBD to [RFC-to-be]
- changed [IANA-PERF-METRIC] from normative to informative reference
- replace the xxx in the IPFIX IE Reference field to a pointer to the IP Perf. Metric Regitry.
  ex: OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Max (TBD3) in the IANA Performance Metric Registry
- I updated the IPFIX IE to point to the perf metric.
  ex:

                Description:

                This Information Element identifies the sum of the path delay
                between the IOAM encapsulation node and the local node with the
                IOAM domain (either an IOAM transit node or an IOAM decapsulation
                node) in microseconds, according to
                OWDelay_HybridType1_Passive_IP_RFC[RFC-to-be]_Seconds_Sum in the
                IANA Performance Metric Registry.
